### PR TITLE
Allow the deletion of saved covers on double click

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -125,7 +125,9 @@ function appendCoversToSavedView() {
     
     let newSection = document.createElement('section');
     newSection.classList.add('mini-cover');
+    newSection.setAttribute('id', thisCover.id)
     savedCoversSection.appendChild(newSection);
+    
 
     let img = document.createElement('img');
     img.classList.add('cover-image');
@@ -151,6 +153,11 @@ function appendCoversToSavedView() {
     overlay.classList.add('overlay');
     overlay.src = "./assets/overlay.png";
     newSection.append(overlay);
+
+    newSection.addEventListener('dblclick', (e) => {
+      var coverToRemove = document.getElementById(`${thisCover.id}`);
+      coverToRemove.remove();
+    });
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -127,7 +127,6 @@ function appendCoversToSavedView() {
     newSection.classList.add('mini-cover');
     newSection.setAttribute('id', thisCover.id)
     savedCoversSection.appendChild(newSection);
-    
 
     let img = document.createElement('img');
     img.classList.add('cover-image');


### PR DESCRIPTION
### Description

This will allow users to delete covers from their saved covers view with a simple double-click!

### Testing

- From the saved covers view, if a user double clicks a saved poster, it will be deleted
- HTML onclick attributes should not be used in any HTML code - all functionality should be through JavaScript
- ensure that the cover element no longer exists in the DOM anymore!